### PR TITLE
Add missing return type for 'requiredConfigValueNotSet' and 'getPackageProviders' methods

### DIFF
--- a/src/Exceptions/CouldNotExecuteCommand.php
+++ b/src/Exceptions/CouldNotExecuteCommand.php
@@ -12,7 +12,7 @@ class CouldNotExecuteCommand extends Exception
         return new static("Could not find a host named `{$hostName}` in the config file");
     }
 
-    public static function requiredConfigValueNotSet($hostName, string $configValue)
+    public static function requiredConfigValueNotSet($hostName, string $configValue): self
     {
         return new static("The required config value `{$configValue}` is not set for host `{$hostName}`");
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@ use Spatie\Remote\RemoteServiceProvider;
 
 class TestCase extends Orchestra
 {
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             RemoteServiceProvider::class,


### PR DESCRIPTION
- Add missing return type for `requiredConfigValueNotSet` and `getPackageProviders` methods