### PR TITLE
nitpick: use unpacking syntax

### DIFF
--- a/src/Config/RemoteConfig.php
+++ b/src/Config/RemoteConfig.php
@@ -20,11 +20,6 @@ class RemoteConfig
             }
         }
 
-        return new HostConfig(
-            $configValues['host'],
-            $configValues['port'],
-            $configValues['user'],
-            $configValues['path'],
-        );
+        return new HostConfig(...$configValues);
     }
 }


### PR DESCRIPTION
Due to PHP8's named argument, it's possible here to unpack an array with string keys.
