### PR TITLE
feature/run-command-on-multiple-servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This is the contents of the published config file:
 
 ```php
 return [
+
     /*
      * This host will be used if none is specified
      * when executing the `remote` command.
@@ -46,20 +47,26 @@ return [
     'default_host' => 'default',
 
     /*
+     * Here you can define deafault for the hosts so you don't need to specify on each of the hosts.
+     */
+    'defaults' => [
+        'port' => env('REMOTE_PORT', 22),
+
+        'user' => env('REMOTE_USER'),
+        /*
+         * The package will cd to the given path before executing the given command.
+         */
+        'path' => env('REMOTE_PATH'),
+
+        'tag' => 'tag',
+    ],
+
+    /*
      * Here you can define the hosts where the commands should be executed.
      */
     'hosts' => [
         'default' => [
             'host' => env('REMOTE_HOST'),
-
-            'port' => env('REMOTE_PORT', 22),
-
-            'user' => env('REMOTE_USER'),
-
-            /*
-             * The package will cd to the given path before executing the given command.
-             */
-            'path' => env('REMOTE_PATH'),
         ]
     ],
 ];

--- a/config/remote.php
+++ b/config/remote.php
@@ -13,11 +13,14 @@ return [
      */
     'defaults' => [
         'port' => env('REMOTE_PORT', 22),
+
         'user' => env('REMOTE_USER'),
         /*
          * The package will cd to the given path before executing the given command.
          */
         'path' => env('REMOTE_PATH'),
+
+        'tag' => 'tag',
     ],
 
     /*

--- a/config/remote.php
+++ b/config/remote.php
@@ -9,20 +9,23 @@ return [
     'default_host' => 'default',
 
     /*
+     * Here you can define deafault for the hosts so you don't need to specify on each of the hosts.
+     */
+    'defaults' => [
+        'port' => env('REMOTE_PORT', 22),
+        'user' => env('REMOTE_USER'),
+        /*
+         * The package will cd to the given path before executing the given command.
+         */
+        'path' => env('REMOTE_PATH'),
+    ],
+
+    /*
      * Here you can define the hosts where the commands should be executed.
      */
     'hosts' => [
         'default' => [
             'host' => env('REMOTE_HOST'),
-
-            'port' => env('REMOTE_PORT', 22),
-
-            'user' => env('REMOTE_USER'),
-
-            /*
-             * The package will cd to the given path before executing the given command.
-             */
-            'path' => env('REMOTE_PATH'),
         ]
     ],
 ];

--- a/src/Config/HostConfig.php
+++ b/src/Config/HostConfig.php
@@ -5,10 +5,12 @@ namespace Spatie\Remote\Config;
 class HostConfig
 {
     public function __construct(
+        public string $name,
         public string $host,
         public int $port,
         public string $user,
         public string $path,
+        public ?string $tag,
     ) {
     }
 }

--- a/src/Config/RemoteConfig.php
+++ b/src/Config/RemoteConfig.php
@@ -14,7 +14,7 @@ class RemoteConfig
             throw CouldNotExecuteCommand::hostNotFoundInConfig($hostName);
         }
 
-        $configValues = array_merge([$hostName], $configValues, config('remote.defaults'));
+        $configValues = array_merge(['name' => $hostName], $configValues, config('remote.defaults'));
 
         foreach (['host', 'port', 'user', 'path'] as $configValue) {
             if (is_null($configValues[$configValue])) {

--- a/src/Config/RemoteConfig.php
+++ b/src/Config/RemoteConfig.php
@@ -14,6 +14,8 @@ class RemoteConfig
             throw CouldNotExecuteCommand::hostNotFoundInConfig($hostName);
         }
 
+        $configValues = array_merge([$hostName], $configValues, config('remote.defaults'));
+
         foreach (['host', 'port', 'user', 'path'] as $configValue) {
             if (is_null($configValues[$configValue])) {
                 throw CouldNotExecuteCommand::requiredConfigValueNotSet($hostName, $configValue);


### PR DESCRIPTION
Changes:
- Added support for running multiple servers at once
- Added tags for grouping servers to be run together.
- Default host config parameters
- Minor refactor of `RemoteCommand` class

I think everything should be backwards compatible.

TODO
- [ ] Update Readme

What do you think?
