### PR TITLE
fix: Allow dots on hosts

### DIFF
--- a/src/Config/RemoteConfig.php
+++ b/src/Config/RemoteConfig.php
@@ -8,7 +8,8 @@ class RemoteConfig
 {
     public static function getHost(string $hostName): HostConfig
     {
-        $configValues = config("remote.hosts.{$hostName}");
+        $configValues = config("remote.hosts") ?? [];
+        $configValues = $configValues[$hostName] ?? null;
 
         if (is_null($configValues)) {
             throw CouldNotExecuteCommand::hostNotFoundInConfig($hostName);

--- a/tests/RemoteTest.php
+++ b/tests/RemoteTest.php
@@ -84,4 +84,21 @@ class RemoteTest extends TestCase
 
         Artisan::call('remote test --debug');
     }
+
+    /** @test */
+    public function it_can_get_the_config_with_dots()
+    {
+        config()->set('remote.hosts', [
+            'example.com' => [
+                'host' => 'example.com',
+                'port' => 22,
+                'user' => 'user',
+                'path' => '/home/forge/test-path',
+            ],
+        ]);
+
+        Artisan::call('remote test --debug --host=example.com');
+
+        $this->assertMatchesSnapshot(Artisan::output());
+    }
 }

--- a/tests/__snapshots__/RemoteTest__it_can_get_the_config_with_dots__1.txt
+++ b/tests/__snapshots__/RemoteTest__it_can_get_the_config_with_dots__1.txt
@@ -1,0 +1,4 @@
+ssh -p 22 user@example.com 'bash -se' << \EOF-SPATIE-SSH
+cd /home/forge/test-path
+php artisan test
+EOF-SPATIE-SSH


### PR DESCRIPTION
This PR fix an issue when using dots on an `host` due to the `config("remote.hosts.{$hostName}")`.

## Example

```php
// config/remote.php

    'hosts' => [
        'example.com' => [
            'host' => 'example.com',
            'port' => env('REMOTE_PORT', 22),
            'user' => env('REMOTE_USER'),
        ]
    ],
```