### PR TITLE
feat: Allow ANSI on `artisan` calls to match local artisan.

### DIFF
--- a/tests/RemoteTest.php
+++ b/tests/RemoteTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Remote\Tests;
 
 use Illuminate\Support\Facades\Artisan;
+use Spatie\Remote\Commands\RemoteCommand;
 use Spatie\Remote\Exceptions\CouldNotExecuteCommand;
 use Spatie\Snapshots\MatchesSnapshots;
 
@@ -13,6 +14,8 @@ class RemoteTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        RemoteCommand::resolveTerminalWidthUsing(fn () => 50);
 
         config()->set('remote.hosts.default', [
             'host' => 'example.com',

--- a/tests/__snapshots__/RemoteTest__it_can_execute_a_raw_command__1.txt
+++ b/tests/__snapshots__/RemoteTest__it_can_execute_a_raw_command__1.txt
@@ -1,4 +1,5 @@
 ssh -p 22 user@example.com 'bash -se' << \EOF-SPATIE-SSH
+export COLUMNS=50
 cd /home/forge/test-path
 test
 EOF-SPATIE-SSH

--- a/tests/__snapshots__/RemoteTest__it_can_execute_a_remote_command__1.txt
+++ b/tests/__snapshots__/RemoteTest__it_can_execute_a_remote_command__1.txt
@@ -1,4 +1,5 @@
 ssh -p 22 user@example.com 'bash -se' << \EOF-SPATIE-SSH
+export COLUMNS=50
 cd /home/forge/test-path
-php artisan test
+php artisan test --ansi
 EOF-SPATIE-SSH


### PR DESCRIPTION
This PR adds the capability to receive the `artisan` output with colors.

It also set the width to be the same as the current terminal, and add `\n` before and after the call to match the local artisan output.

## Local

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/823088/198164330-8c416b2a-3bb3-43b1-8980-4f130e58f901.png">


## Remote Before

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/823088/198164569-550f5ada-cc0c-4fa9-8074-84e4bb87b62a.png">


## Remote After

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/823088/198164523-981a17ed-7562-4f5d-ac9a-d04ba04a22e9.png">
