### PR TITLE
Update README to set private_key_path correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ return [
             /*
              * Optional. Path to the private key on your computer if your remote server requires it.
              */
-            'private_key_path' => env('REMOTE_PRIVATE_KEY_PATH'),
+            'privateKeyPath' => env('REMOTE_PRIVATE_KEY_PATH'),
         ]
     ],
 ];


### PR DESCRIPTION
The README is incorrect. `private_key_path` is outdated and `privateKeyPath` is used instead.