### PR TITLE
Add support for custom PHP binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ return [
      * when executing the `remote` command.
      */
     'default_host' => 'default',
-    
+
     /*
     * When set to true, A confirmation prompt will be shown before executing the `remote` command.
     */
@@ -63,11 +63,16 @@ return [
              * The package will cd to the given path before executing the given command.
              */
             'path' => env('REMOTE_PATH'),
-            
+
             /*
              * Optional. Path to the private key on your computer if your remote server requires it.
              */
             'privateKeyPath' => env('REMOTE_PRIVATE_KEY_PATH'),
+
+            /*
+             * Optional. Path to the php binary on your remote server.
+             */
+            'phpPath' => env('REMOTE_PHP_PATH', 'php'),
         ]
     ],
 ];
@@ -129,8 +134,8 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 ## Credits
 
-- [Freek Van der Herten](https://github.com/freekmurze)
-- [All Contributors](../../contributors)
+-   [Freek Van der Herten](https://github.com/freekmurze)
+-   [All Contributors](../../contributors)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ return [
      * when executing the `remote` command.
      */
     'default_host' => 'default',
-
+    
     /*
     * When set to true, A confirmation prompt will be shown before executing the `remote` command.
     */
@@ -63,12 +63,12 @@ return [
              * The package will cd to the given path before executing the given command.
              */
             'path' => env('REMOTE_PATH'),
-
+            
             /*
              * Optional. Path to the private key on your computer if your remote server requires it.
              */
             'privateKeyPath' => env('REMOTE_PRIVATE_KEY_PATH'),
-
+            
             /*
              * Optional. Path to the php binary on your remote server.
              */
@@ -134,8 +134,8 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 ## Credits
 
--   [Freek Van der Herten](https://github.com/freekmurze)
--   [All Contributors](../../contributors)
+- [Freek Van der Herten](https://github.com/freekmurze)
+- [All Contributors](../../contributors)
 
 ## License
 

--- a/config/remote.php
+++ b/config/remote.php
@@ -28,6 +28,11 @@ return [
              * The package will cd to the given path before executing the given command.
              */
             'path' => env('REMOTE_PATH'),
+
+            /*
+             * Optional. Path to the php binary on your remote server.
+             */
+            'phpPath' => env('REMOTE_PHP_PATH', 'php'),
         ]
     ],
 ];

--- a/src/Commands/RemoteCommand.php
+++ b/src/Commands/RemoteCommand.php
@@ -57,7 +57,7 @@ class RemoteCommand extends Command
         $command = $this->argument('rawCommand');
 
         if (! $this->option('raw')) {
-            $command = "php artisan {$command} --ansi";
+            $command = "{$hostConfig->phpPath} artisan {$command} --ansi";
         }
 
         return [

--- a/src/Config/HostConfig.php
+++ b/src/Config/HostConfig.php
@@ -10,6 +10,7 @@ class HostConfig
         public string $user,
         public string $path,
         public ?string $privateKeyPath = null,
+        public ?string $phpPath = 'php',
     ) {
     }
 }

--- a/tests/RemoteTest.php
+++ b/tests/RemoteTest.php
@@ -86,3 +86,17 @@ it('can get the config with dots', function () {
 
     assertMatchesSnapshot(Artisan::output());
 });
+
+it('can execute a remote command with custom php path', function () {
+    config()->set('remote.hosts.default', [
+        'host' => 'example.com',
+        'port' => 22,
+        'user' => 'user',
+        'path' => '/home/forge/test-path',
+        'phpPath' => '/usr/bin/php8.3',
+    ]);
+
+    Artisan::call('remote test --debug');
+
+    assertMatchesSnapshot(Artisan::output());
+});

--- a/tests/__snapshots__/RemoteTest__it_can_execute_a_remote_command_with_custom_php_path__1.txt
+++ b/tests/__snapshots__/RemoteTest__it_can_execute_a_remote_command_with_custom_php_path__1.txt
@@ -1,0 +1,5 @@
+ssh -p 22 user@example.com 'bash -se' << \EOF-SPATIE-SSH
+export COLUMNS=50
+cd /home/forge/test-path
+/usr/bin/php8.3 artisan test --ansi
+EOF-SPATIE-SSH


### PR DESCRIPTION
We ran into the issue that the incorrect php binary was used on our Forge server.
the `php` alias from the package was using `/usr/bin/php` instead of our required alias `php8.3` which uses `/usr/bin/php8.3`.

So now we've added an optional config option that enables setting a custom php binary path.
Test is added as well. 
